### PR TITLE
fix: use relative base path for Vite

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: "./",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- fix blank page on deployment by using relative base path in Vite config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run lint` *(fails: A `require()` style import is forbidden; An interface declaring no members is equivalent to its supertype)*

------
https://chatgpt.com/codex/tasks/task_e_68c212e616788331a495338bb3a1e7d7