### PR TITLE
Add legal and sitemap pages with SEO updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,9 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
+import TermsOfService from "./pages/TermsOfService";
+import Sitemap from "./pages/Sitemap";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +19,9 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+          <Route path="/terms-of-service" element={<TermsOfService />} />
+          <Route path="/sitemap" element={<Sitemap />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,15 +1,16 @@
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { 
-  Zap, 
-  Phone, 
-  Mail, 
-  MapPin, 
+import {
+  Zap,
+  Phone,
+  Mail,
+  MapPin,
   Clock,
   Facebook,
   Instagram,
   Linkedin
 } from "lucide-react";
+import { Link } from "react-router-dom";
 
 const Footer = () => {
   const serviceAreas = [
@@ -132,9 +133,27 @@ const Footer = () => {
               © 2024 Integrity EV Solutions. All rights reserved. | Licensed Electrical Contractor | Georgia License #EN217457
             </div>
             <div className="flex gap-6">
-              <a href="#privacy" className="hover:text-accent transition-colors">Privacy Policy</a>
-              <a href="#terms" className="hover:text-accent transition-colors">Terms of Service</a>
-              <a href="#sitemap" className="hover:text-accent transition-colors">Sitemap</a>
+              <Link
+                to="/privacy-policy"
+                className="hover:text-accent transition-colors"
+                aria-label="Privacy Policy"
+              >
+                Privacy Policy
+              </Link>
+              <Link
+                to="/terms-of-service"
+                className="hover:text-accent transition-colors"
+                aria-label="Terms of Service"
+              >
+                Terms of Service
+              </Link>
+              <Link
+                to="/sitemap"
+                className="hover:text-accent transition-colors"
+                aria-label="Sitemap"
+              >
+                Sitemap
+              </Link>
             </div>
           </div>
         </div>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+
+interface SEOProps {
+  title: string;
+  description: string;
+}
+
+const SEO = ({ title, description }: SEOProps) => {
+  useEffect(() => {
+    document.title = title;
+    const metaDescription = document.querySelector(
+      'meta[name="description"]'
+    );
+    if (metaDescription) {
+      metaDescription.setAttribute("content", description);
+    } else {
+      const desc = document.createElement("meta");
+      desc.name = "description";
+      desc.content = description;
+      document.head.appendChild(desc);
+    }
+  }, [title, description]);
+
+  return null;
+};
+
+export default SEO;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,12 +5,17 @@ import Services from "@/components/Services";
 import Testimonials from "@/components/Testimonials";
 import ContactForm from "@/components/ContactForm";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 
 const Index = () => {
   return (
     <div className="min-h-screen bg-background">
       <Navigation />
-      <main>
+      <main role="main">
+        <SEO
+          title="Professional EV Charger Installation | Integrity EV Solutions | Georgia"
+          description="Professional EV charger installation in Georgia. Fast, certified, rebate-ready installations by licensed electricians. Serving Atlanta & Northern Georgia. Get your free estimate today!"
+        />
         <Hero />
         <WorkShowcase />
         <Services />

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,29 @@
+import Navigation from "@/components/Navigation";
+import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
+
+const PrivacyPolicy = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <main className="container mx-auto px-4 py-12" role="main">
+        <SEO
+          title="Privacy Policy | Integrity EV Solutions"
+          description="Learn how Integrity EV Solutions collects, uses, and protects your information."
+        />
+        <h1 className="text-3xl font-bold mb-6">Privacy Policy</h1>
+        <p className="mb-4">
+          Integrity EV Solutions respects your privacy. This policy outlines how we handle your
+          personal information when you use our services or website.
+        </p>
+        <p className="mb-4">
+          We collect only the data necessary to provide our services and never sell or share your
+          information without consent. For questions about this policy, please contact us.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default PrivacyPolicy;

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -1,0 +1,41 @@
+import Navigation from "@/components/Navigation";
+import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
+import { Link } from "react-router-dom";
+
+const Sitemap = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <main className="container mx-auto px-4 py-12" role="main">
+        <SEO
+          title="Sitemap | Integrity EV Solutions"
+          description="Browse the Integrity EV Solutions sitemap for quick access to all pages."
+        />
+        <h1 className="text-3xl font-bold mb-6">Sitemap</h1>
+        <nav aria-label="Sitemap">
+          <ul className="list-disc list-inside space-y-2">
+            <li>
+              <Link className="underline hover:text-accent" to="/">
+                Home
+              </Link>
+            </li>
+            <li>
+              <Link className="underline hover:text-accent" to="/privacy-policy">
+                Privacy Policy
+              </Link>
+            </li>
+            <li>
+              <Link className="underline hover:text-accent" to="/terms-of-service">
+                Terms of Service
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Sitemap;

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -1,0 +1,29 @@
+import Navigation from "@/components/Navigation";
+import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
+
+const TermsOfService = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <main className="container mx-auto px-4 py-12" role="main">
+        <SEO
+          title="Terms of Service | Integrity EV Solutions"
+          description="Review the terms and conditions for using Integrity EV Solutions services."
+        />
+        <h1 className="text-3xl font-bold mb-6">Terms of Service</h1>
+        <p className="mb-4">
+          By accessing our website or using our services, you agree to the following terms and
+          conditions. Please read them carefully before proceeding.
+        </p>
+        <p className="mb-4">
+          These terms ensure a clear understanding of our responsibilities and your rights as a
+          customer of Integrity EV Solutions.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default TermsOfService;


### PR DESCRIPTION
## Summary
- add reusable SEO component to manage document titles and meta descriptions
- create Privacy Policy, Terms of Service, and Sitemap pages matching site style
- wire up routes and footer navigation to new pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c22400ac748331a34cd3bfa50505b3