### PR TITLE
feat: add sticky mobile action buttons

### DIFF
--- a/src/components/MobileCTA.tsx
+++ b/src/components/MobileCTA.tsx
@@ -1,0 +1,28 @@
+import { Button } from "@/components/ui/button";
+import { Phone, ClipboardList } from "lucide-react";
+
+/**
+ * MobileCTA renders persistent call-to-action buttons on mobile devices.
+ * The bar sticks to the bottom of the screen and provides quick access
+ * to call/text and request a free estimate without covering the footer.
+ */
+const MobileCTA = () => {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 p-4 md:hidden flex gap-4 bg-background/80 backdrop-blur-sm border-t border-border">
+      <a href="tel:4702622660" className="flex-1">
+        <Button variant="electric" className="w-full h-12 text-base">
+          <Phone className="w-5 h-5" />
+          Text/Call
+        </Button>
+      </a>
+      <a href="#contact" className="flex-1">
+        <Button variant="accent" className="w-full h-12 text-base">
+          <ClipboardList className="w-5 h-5" />
+          Free Estimate
+        </Button>
+      </a>
+    </div>
+  );
+};
+
+export default MobileCTA;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,12 +4,13 @@ import WorkShowcase from "@/components/WorkShowcase";
 import Services from "@/components/Services";
 import Testimonials from "@/components/Testimonials";
 import ContactForm from "@/components/ContactForm";
+import MobileCTA from "@/components/MobileCTA";
 import Footer from "@/components/Footer";
 import SEO from "@/components/SEO";
 
 const Index = () => {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background pb-24 md:pb-0">
       <Navigation />
       <main role="main">
         <SEO
@@ -22,6 +23,7 @@ const Index = () => {
         <Testimonials />
         <ContactForm />
       </main>
+      <MobileCTA />
       <Footer />
     </div>
   );

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,10 +1,11 @@
 import Navigation from "@/components/Navigation";
+import MobileCTA from "@/components/MobileCTA";
 import Footer from "@/components/Footer";
 import SEO from "@/components/SEO";
 
 const PrivacyPolicy = () => {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background pb-24 md:pb-0">
       <Navigation />
       <main className="container mx-auto px-4 py-12" role="main">
         <SEO
@@ -21,6 +22,7 @@ const PrivacyPolicy = () => {
           information without consent. For questions about this policy, please contact us.
         </p>
       </main>
+      <MobileCTA />
       <Footer />
     </div>
   );

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -1,11 +1,12 @@
 import Navigation from "@/components/Navigation";
+import MobileCTA from "@/components/MobileCTA";
 import Footer from "@/components/Footer";
 import SEO from "@/components/SEO";
 import { Link } from "react-router-dom";
 
 const Sitemap = () => {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background pb-24 md:pb-0">
       <Navigation />
       <main className="container mx-auto px-4 py-12" role="main">
         <SEO
@@ -33,6 +34,7 @@ const Sitemap = () => {
           </ul>
         </nav>
       </main>
+      <MobileCTA />
       <Footer />
     </div>
   );

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -1,10 +1,11 @@
 import Navigation from "@/components/Navigation";
+import MobileCTA from "@/components/MobileCTA";
 import Footer from "@/components/Footer";
 import SEO from "@/components/SEO";
 
 const TermsOfService = () => {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background pb-24 md:pb-0">
       <Navigation />
       <main className="container mx-auto px-4 py-12" role="main">
         <SEO
@@ -21,6 +22,7 @@ const TermsOfService = () => {
           customer of Integrity EV Solutions.
         </p>
       </main>
+      <MobileCTA />
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- add MobileCTA component with gradient Text/Call and Free Estimate buttons
- include sticky CTA bar across pages with extra bottom padding to keep footer visible on mobile

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c227b307608331b31320d32b29f759