### PR TITLE
Fix contact form submission via FormSubmit AJAX endpoint

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -31,12 +31,18 @@ const ContactForm = () => {
     const formData = new FormData(e.currentTarget);
     formData.append("_captcha", "false");
 
+    const formObject = Object.fromEntries(formData.entries());
+
     try {
       const response = await fetch(
-        "https://formsubmit.co/integrityevsolutions@gmail.com",
+        "https://formsubmit.co/ajax/integrityevsolutions@gmail.com",
         {
           method: "POST",
-          body: formData,
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify(formObject),
         }
       );
 


### PR DESCRIPTION
## Summary
- use FormSubmit AJAX endpoint and JSON payload for contact form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c231f7734c83319bc4ee0296ace2aa