### PR TITLE
fix: offset navbar on policy pages

### DIFF
--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -7,7 +7,10 @@ const PrivacyPolicy = () => {
   return (
     <div className="min-h-screen bg-background pb-24 md:pb-0">
       <Navigation />
-      <main className="container mx-auto px-4 py-12" role="main">
+      <main
+        className="container mx-auto px-4 pt-28 md:pt-32 pb-12"
+        role="main"
+      >
         <SEO
           title="Privacy Policy | Integrity EV Solutions"
           description="Learn how Integrity EV Solutions collects, uses, and protects your information."

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -8,7 +8,10 @@ const Sitemap = () => {
   return (
     <div className="min-h-screen bg-background pb-24 md:pb-0">
       <Navigation />
-      <main className="container mx-auto px-4 py-12" role="main">
+      <main
+        className="container mx-auto px-4 pt-28 md:pt-32 pb-12"
+        role="main"
+      >
         <SEO
           title="Sitemap | Integrity EV Solutions"
           description="Browse the Integrity EV Solutions sitemap for quick access to all pages."

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -7,7 +7,10 @@ const TermsOfService = () => {
   return (
     <div className="min-h-screen bg-background pb-24 md:pb-0">
       <Navigation />
-      <main className="container mx-auto px-4 py-12" role="main">
+      <main
+        className="container mx-auto px-4 pt-28 md:pt-32 pb-12"
+        role="main"
+      >
         <SEO
           title="Terms of Service | Integrity EV Solutions"
           description="Review the terms and conditions for using Integrity EV Solutions services."


### PR DESCRIPTION
## Summary
- ensure privacy policy, terms of service, and sitemap pages start below fixed navigation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2351eeae883319b0a2e793eea152c