### PR TITLE
Improve mobile menu readability and animation

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -76,7 +76,7 @@ const Navigation = () => {
 
         {/* Mobile Menu */}
         {isMenuOpen && (
-          <div className="lg:hidden absolute top-full left-0 right-0 bg-white/98 backdrop-blur-md border-b border-border shadow-lg">
+          <div className="lg:hidden absolute top-full left-0 right-0 bg-white backdrop-blur-md border-b border-border shadow-lg animate-in fade-in slide-in-from-top duration-300">
             <div className="p-4 space-y-4">
               {navItems.map((item) => (
                 <a


### PR DESCRIPTION
## Summary
- ensure mobile menu uses solid background for readability
- add slide/fade animation when mobile menu opens for better UX

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c23552f30083318573fddd92e1d093