### PR TITLE
Ensure contact form button resets after submit

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -44,6 +44,8 @@ const ContactForm = () => {
       });
     } catch {
       // Ignore any errors from the submission request
+    } finally {
+      setIsSubmitting(false);
     }
 
     toast({
@@ -53,7 +55,6 @@ const ContactForm = () => {
     e.currentTarget.reset();
     setService("");
     setTimeline("");
-    setIsSubmitting(false);
   };
 
   const contactMethods = [


### PR DESCRIPTION
## Summary
- Prevent contact form button spinner from persisting by resetting submission state in a finally block

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c23d2e91d48331a91615fcd668440e