### PR TITLE
fix: link hero work button to showcase section

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -114,7 +114,7 @@ const Hero = () => {
                 variant="outline" 
                 size="lg"
                 className="bg-white/90 border-2 border-white text-gray-900 hover:bg-white hover:text-gray-800 backdrop-blur-sm scale-on-hover text-lg px-8 py-7 h-auto font-semibold shadow-lg transition-all duration-300"
-                onClick={() => document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' })}
+                onClick={() => document.getElementById('work')?.scrollIntoView({ behavior: 'smooth' })}
               >
                 📸 View Our Work
               </Button>


### PR DESCRIPTION
## Summary
- ensure Hero "View Our Work" button scrolls to WorkShowcase section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c35387a6dc83318135178d7e17d280