### PR TITLE
fix: adjust hero owner photo positioning

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -135,7 +135,7 @@ const Hero = () => {
 
       {/* Owner Photo */}
       <div
-        className="z-20 fade-in-up absolute md:bottom-20 md:right-10 bottom-5 left-1/2 transform -translate-x-1/2 md:left-auto md:translate-x-0"
+        className="z-20 fade-in-up relative mx-auto mt-10 md:absolute md:bottom-20 md:right-10 md:mt-0"
         style={{ animationDelay: "0.8s" }}
       >
         <div className="relative w-32 sm:w-48 md:w-64">


### PR DESCRIPTION
## Summary
- prevent owner photo from overlapping hero text by using relative positioning on mobile and absolute on larger screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c3724d0fe48331b00d86cd389725e9