### PR TITLE
Replace Nextdoor rating reference with Google rating

### DIFF
--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -147,8 +147,8 @@ const Testimonials = () => {
               className="scale-on-hover"
             >
               <Badge className="bg-white text-emerald-700 px-6 py-3 cursor-pointer hover:bg-white/90 transition-colors text-base font-semibold">
-                ⭐⭐⭐⭐⭐ 5.0 Nextdoor Rating
-              </Badge>  
+                ⭐⭐⭐⭐⭐ 5.0 Google Rating
+              </Badge>
             </a>
             <span className="text-white/80">•</span>
             <Badge className="bg-white text-emerald-700 px-6 py-3 text-base font-semibold">


### PR DESCRIPTION
## Summary
- Update testimonial badge text to show a 5.0 Google Rating instead of Nextdoor.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4ee8717548331930bc15f6e6e632a