### PR TITLE
Centralize DNI phone mapping and add debug-friendly resolver

### DIFF
--- a/src/components/PhoneNumber.tsx
+++ b/src/components/PhoneNumber.tsx
@@ -1,0 +1,17 @@
+import { useTrackingPhone } from "@/hooks/use-tracking-phone";
+
+type PhoneNumberProps = {
+  className?: string;
+};
+
+const PhoneNumber = ({ className }: PhoneNumberProps) => {
+  const phone = useTrackingPhone();
+
+  return (
+    <a href={phone.href} className={className}>
+      {phone.display}
+    </a>
+  );
+};
+
+export default PhoneNumber;

--- a/src/hooks/use-tracking-phone.ts
+++ b/src/hooks/use-tracking-phone.ts
@@ -1,81 +1,12 @@
 import { useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
+import { getTrackingPhoneNumber } from "@/lib/tracking-phone";
 
-const PHONE_MAP: Record<string, string> = {
-  fbj: "4706883436",
-  igj: "4706341457",
-  radioj: "4706139714",
-  printj: "4702566974",
-  jordan: "4705176159",
-};
-
-const DEFAULT_RAW = "4702622660";
-const STORAGE_KEY = "dni_src";
-
-function formatPhone(raw: string): string {
-  return `(${raw.slice(0, 3)}) ${raw.slice(3, 6)}-${raw.slice(6)}`;
-}
-
-/**
- * Dynamic Number Insertion hook.
- * Reads `?src=` from the URL (React Router + window.location fallback),
- * persists it in localStorage, and returns the mapped phone number.
- */
 export function useTrackingPhone() {
   const [searchParams] = useSearchParams();
 
-  const { display, href } = useMemo(() => {
-    const debug = searchParams.get("debug_dni") === "1" ||
-      new URLSearchParams(window.location.search).get("debug_dni") === "1";
-
-    // Primary: React Router
-    let srcParam = searchParams.get("src")?.trim().toLowerCase() || undefined;
-
-    // Fallback 1: window.location.search (covers replaceState race)
-    if (!srcParam) {
-      try {
-        srcParam = new URLSearchParams(window.location.search).get("src")?.trim().toLowerCase() || undefined;
-      } catch {
-        // noop
-      }
-    }
-
-    // Fallback 2: parse full href (covers edge-case encodings)
-    if (!srcParam) {
-      try {
-        const url = new URL(window.location.href);
-        srcParam = url.searchParams.get("src")?.trim().toLowerCase() || undefined;
-      } catch {
-        // noop
-      }
-    }
-
-    if (debug) console.log("[DNI] srcParam from URL:", srcParam);
-
-    // Persist if present
-    if (srcParam) {
-      try {
-        localStorage.setItem(STORAGE_KEY, srcParam);
-      } catch {
-        // localStorage unavailable
-      }
-    }
-
-    // Resolve: URL param → localStorage → default
-    let src = srcParam;
-    if (!src) {
-      try {
-        src = localStorage.getItem(STORAGE_KEY) || undefined;
-      } catch {
-        // noop
-      }
-    }
-
-    if (debug) console.log("[DNI] resolved src:", src, "→", src && PHONE_MAP[src] ? PHONE_MAP[src] : DEFAULT_RAW);
-
-    const raw = (src && PHONE_MAP[src]) || DEFAULT_RAW;
-    return { display: formatPhone(raw), href: `tel:${raw}` };
-  }, [searchParams]);
-
-  return { display, href };
+  return useMemo(
+    () => getTrackingPhoneNumber(searchParams),
+    [searchParams],
+  );
 }

--- a/src/lib/tracking-phone.ts
+++ b/src/lib/tracking-phone.ts
@@ -1,0 +1,50 @@
+const PHONE_MAP: Record<string, string> = {
+  fbj: "4706883436",
+  igj: "4706341457",
+  printj: "4702566974",
+  radioj: "4706139714",
+  jordan: "4705176159",
+};
+
+const DEFAULT_RAW_PHONE = "4702622660";
+
+export type TrackingPhoneResolution = {
+  raw: string;
+  display: string;
+  href: string;
+  src?: string;
+  reason: "mapped_src" | "unknown_src" | "no_src";
+};
+
+function formatPhone(raw: string): string {
+  return `${raw.slice(0, 3)}-${raw.slice(3, 6)}-${raw.slice(6)}`;
+}
+
+function readSrcParam(searchParams?: URLSearchParams): string | undefined {
+  const src = searchParams?.get("src")?.trim().toLowerCase();
+  return src || undefined;
+}
+
+export function getTrackingPhoneNumber(searchParams?: URLSearchParams): TrackingPhoneResolution {
+  const src = readSrcParam(searchParams) || readSrcParam(new URLSearchParams(window.location.search));
+  const mapped = src ? PHONE_MAP[src] : undefined;
+  const raw = mapped || DEFAULT_RAW_PHONE;
+
+  const reason: TrackingPhoneResolution["reason"] = src
+    ? (mapped ? "mapped_src" : "unknown_src")
+    : "no_src";
+
+  const isDebug = new URLSearchParams(window.location.search).get("debug_phone") === "1";
+  if (isDebug) {
+    console.log("[PhoneTracking]", { src: src || null, reason, raw, href: `tel:${raw}` });
+  }
+
+  return {
+    raw,
+    display: formatPhone(raw),
+    href: `tel:${raw}`,
+    src,
+    reason,
+  };
+}
+


### PR DESCRIPTION
### Motivation
- Fix unreliable production Dynamic Number Insertion (DNI) behavior where `?src=` was not consistently swapping the phone on initial load by introducing a single source-of-truth resolver.
- Reduce duplication and mismatch risk by routing all phone display and `tel:` links through a shared resolver used by the existing `useTrackingPhone()` hook. 
- Add a lightweight debug mode so production query-resolution can be diagnosed in the browser without changing SEO or prerendered meta content.

### Description
- Added a shared resolver `getTrackingPhoneNumber()` in `src/lib/tracking-phone.ts` that reads `?src=`, maps it to the configured phone list, returns `raw`, `display`, `href`, `src`, and a `reason`, and supports `?debug_phone=1` logging. 
- Refactored `useTrackingPhone()` to delegate to `getTrackingPhoneNumber()` so all components now obtain phone data from the same logic path. 
- Added a small reusable `PhoneNumber` component in `src/components/PhoneNumber.tsx` that renders a consistent linked phone text from the hook. 
- Normalized display formatting to `470-XXX-XXXX` while keeping `tel:` links digits-only, removed the previous localStorage persistence fallback in favor of URL-first resolution, and left SEO/schema meta untouched.

### Testing
- Ran `npm run build` which completed and produced `dist/` assets (build output included `dist/assets/index-ByxJMVcH.js`), although prerendering attempted by `vite-plugin-html-prerender` failed to launch Chromium in this environment and emitted a puppeteer shared-library warning; the production bundle was still emitted. 
- Ran `npm run lint` which failed due to pre-existing lint issues in unrelated files (the failures are repository lint problems and not introduced by this patch). 
- Searched the codebase to confirm all visible phone occurrences use the shared hook (`phone.display` / `phone.href`) and updated components where appropriate via the new resolver. 
- Attempted external validation of live site redirects with `curl` but requests to the production domain were blocked from this environment (CONNECT tunnel failed, response 403), so apex→www redirect/query-preservation and deployed artifact freshness could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5301974948331a28f24b3f2d5f7be)