### PR TITLE
Contact form overhaul: mailto flow, validation & UI improvements; sessionStorage fix and prerender update

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,31 +1,32 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { z } from "zod";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Badge } from "@/components/ui/badge";
-import { useToast } from "@/hooks/use-toast";
-import { 
-  Phone, 
-  Mail, 
-  MapPin, 
-  Clock, 
+import {
+  CheckCircle,
+  Clock,
+  ExternalLink,
+  Mail,
+  MapPin,
+  Phone,
   Send,
   Zap,
-  CheckCircle
 } from "lucide-react";
 import { useTrackingPhone } from "@/hooks/use-tracking-phone";
 
-// Validation schema
+const CONTACT_EMAIL = "integrityevsolutions@gmail.com";
+const MAILTO_SUBJECT = "Free estimate request - Integrity EV Solutions";
+
 const contactFormSchema = z.object({
   firstName: z.string().trim().min(1, "First name is required").max(50, "First name must be less than 50 characters"),
   lastName: z.string().trim().min(1, "Last name is required").max(50, "Last name must be less than 50 characters"),
-  email: z.string().trim().email("Invalid email address").max(255, "Email must be less than 255 characters"),
-  phone: z.string().trim().min(10, "Phone number must be at least 10 digits").max(20, "Phone number too long").regex(/^[\d\s\-\(\)\+]+$/, "Invalid phone number format"),
+  email: z.string().trim().email("Enter a valid email address").max(255, "Email must be less than 255 characters"),
+  phone: z.string().trim().min(10, "Phone number must be at least 10 digits").max(20, "Phone number too long").regex(/^[\d\s\-()+.]+$/, "Enter a valid phone number"),
   service: z.string().min(1, "Please select a service"),
   city: z.string().trim().min(1, "City is required").max(100, "City name too long"),
   timeline: z.string().optional(),
@@ -33,78 +34,149 @@ const contactFormSchema = z.object({
 });
 
 type ContactFormData = z.infer<typeof contactFormSchema>;
+type ContactFormErrors = Partial<Record<keyof ContactFormData, string>>;
 
-const FORMSUBMIT_FORM_ENDPOINT = "https://formsubmit.co/integrityevsolutions@gmail.com";
+const initialFormData: ContactFormData = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  phone: "",
+  service: "",
+  city: "",
+  timeline: "",
+  details: "",
+};
+
+const serviceOptions = [
+  { value: "Residential EV Charger Installation", label: "Residential EV Charger Installation" },
+  { value: "Commercial EV Charging", label: "Commercial EV Charging" },
+  { value: "Tesla Powerwall Installation", label: "Tesla Powerwall Installation" },
+  { value: "Electrical Panel Upgrade", label: "Electrical Panel Upgrade" },
+  { value: "General Electrical Work", label: "General Electrical Work" },
+  { value: "Emergency Service", label: "Emergency Service" },
+  { value: "Consultation Only", label: "Consultation Only" },
+];
+
+const timelineOptions = [
+  { value: "As soon as possible", label: "As soon as possible" },
+  { value: "Within 1-2 weeks", label: "Within 1-2 weeks" },
+  { value: "Within 1 month", label: "Within 1 month" },
+  { value: "Flexible", label: "I'm flexible" },
+];
+
+function buildEstimateSummary(data: ContactFormData, utmParams: Record<string, string>) {
+  const fullName = `${data.firstName.trim()} ${data.lastName.trim()}`.trim();
+  const bodyLines = [
+    "New estimate request from integrityevsolutions.com",
+    "",
+    `Name: ${fullName}`,
+    `Email: ${data.email.trim()}`,
+    `Phone: ${data.phone.trim()}`,
+    `Service needed: ${data.service}`,
+    `City: ${data.city.trim()}`,
+    `Preferred timeline: ${data.timeline || "Not specified"}`,
+    "",
+    "Project details:",
+    data.details?.trim() || "Not provided",
+    "",
+    "Lead attribution:",
+    `Source: ${utmParams.utm_source || "Not provided"}`,
+    `Medium: ${utmParams.utm_medium || "Not provided"}`,
+    `Campaign: ${utmParams.utm_campaign || "Not provided"}`,
+  ];
+
+  return bodyLines.join("\n");
+}
+
+function buildMailtoLink(data: ContactFormData, utmParams: Record<string, string>) {
+  return `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(MAILTO_SUBJECT)}&body=${encodeURIComponent(buildEstimateSummary(data, utmParams))}`;
+}
 
 const ContactForm = () => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [service, setService] = useState("");
-  const [timeline, setTimeline] = useState("");
-  const [errors, setErrors] = useState<Partial<Record<keyof ContactFormData, string>>>({});
+  const [formData, setFormData] = useState<ContactFormData>(initialFormData);
+  const [errors, setErrors] = useState<ContactFormErrors>({});
+  const [mailtoLink, setMailtoLink] = useState(`mailto:${CONTACT_EMAIL}`);
+  const [hasValidated, setHasValidated] = useState(false);
+  const [copyMessage, setCopyMessage] = useState("");
   const [utmParams, setUtmParams] = useState({
-    utm_source: '',
-    utm_medium: '',
-    utm_campaign: ''
+    utm_source: "",
+    utm_medium: "",
+    utm_campaign: "",
   });
-  const { toast } = useToast();
   const phone = useTrackingPhone();
 
-  // Capture UTM parameters for lead attribution
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const captured = {
-      utm_source: params.get('utm_source') || localStorage.getItem('utm_source') || '',
-      utm_medium: params.get('utm_medium') || localStorage.getItem('utm_medium') || '',
-      utm_campaign: params.get('utm_campaign') || localStorage.getItem('utm_campaign') || ''
+      utm_source: params.get("utm_source") || localStorage.getItem("utm_source") || "",
+      utm_medium: params.get("utm_medium") || localStorage.getItem("utm_medium") || "",
+      utm_campaign: params.get("utm_campaign") || localStorage.getItem("utm_campaign") || "",
     };
-    
-    // Store in localStorage so they persist across page navigations
-    if (params.get('utm_source')) {
-      localStorage.setItem('utm_source', params.get('utm_source')!);
-      localStorage.setItem('utm_medium', params.get('utm_medium') || '');
-      localStorage.setItem('utm_campaign', params.get('utm_campaign') || '');
+
+    if (params.get("utm_source")) {
+      localStorage.setItem("utm_source", params.get("utm_source") || "");
+      localStorage.setItem("utm_medium", params.get("utm_medium") || "");
+      localStorage.setItem("utm_campaign", params.get("utm_campaign") || "");
     }
-    
+
     setUtmParams(captured);
   }, []);
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    setErrors({});
+  useEffect(() => {
+    setMailtoLink(buildMailtoLink(formData, utmParams));
+  }, [formData, utmParams]);
 
-    const formData = new FormData(e.currentTarget);
-    const formObject = {
-      firstName: formData.get("firstName") as string,
-      lastName: formData.get("lastName") as string,
-      email: formData.get("email") as string,
-      phone: formData.get("phone") as string,
-      service: service,
-      city: formData.get("city") as string,
-      timeline: timeline || undefined,
-      details: formData.get("details") as string || undefined,
-    };
+  const updateField = (field: keyof ContactFormData, value: string) => {
+    setFormData((current) => ({ ...current, [field]: value }));
+    if (errors[field]) {
+      setErrors((current) => ({ ...current, [field]: undefined }));
+    }
+  };
 
-    // Validate form data
-    const result = contactFormSchema.safeParse(formObject);
-    if (!result.success) {
-      e.preventDefault();
-      const fieldErrors: Partial<Record<keyof ContactFormData, string>> = {};
-      result.error.errors.forEach((err) => {
-        if (err.path[0]) {
-          fieldErrors[err.path[0] as keyof ContactFormData] = err.message;
-        }
-      });
-      setErrors(fieldErrors);
-      toast({
-        title: "Please fix the errors",
-        description: "Some fields have invalid values.",
-        variant: "destructive",
-      });
+  const copyEstimateDetails = async () => {
+    if (!validateForm()) {
       return;
     }
 
-    // Validation passed — allow the native POST to FormSubmit to proceed.
-    // FormSubmit will redirect the user to the /thank-you page on success.
-    setIsSubmitting(true);
+    const summary = buildEstimateSummary(formData, utmParams);
+    try {
+      await navigator.clipboard.writeText(summary);
+      setCopyMessage("Estimate details copied. Paste them into a text or email to send them manually.");
+    } catch {
+      setCopyMessage("Copy did not work in this browser. Select the text below and copy it manually.");
+    }
+  };
+
+  const validateForm = () => {
+    const result = contactFormSchema.safeParse(formData);
+
+    if (result.success) {
+      setErrors({});
+      setHasValidated(true);
+      return true;
+    }
+
+    const fieldErrors: ContactFormErrors = {};
+    result.error.errors.forEach((err) => {
+      const fieldName = err.path[0] as keyof ContactFormData | undefined;
+      if (fieldName) {
+        fieldErrors[fieldName] = err.message;
+      }
+    });
+
+    setErrors(fieldErrors);
+    setHasValidated(false);
+    setCopyMessage("");
+    return false;
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!validateForm()) {
+      return;
+    }
+
+    window.location.href = buildMailtoLink(formData, utmParams);
   };
 
   const contactMethods = [
@@ -114,15 +186,15 @@ const ContactForm = () => {
       value: phone.display,
       description: "Mon–Fri: 8 am–6 pm",
       action: "Call Now",
-      gradient: "bg-gradient-primary"
+      gradient: "bg-gradient-primary",
     },
     {
       icon: <Mail className="w-6 h-6" />,
       title: "Email",
-      value: "integrityevsolutions@gmail.com",
+      value: CONTACT_EMAIL,
       description: "We respond within 24 hours",
       action: "Send Email",
-      gradient: "bg-gradient-accent"
+      gradient: "bg-gradient-accent",
     },
     {
       icon: <MapPin className="w-6 h-6" />,
@@ -130,14 +202,13 @@ const ContactForm = () => {
       value: "All of Northern Georgia",
       description: "Licensed statewide",
       action: "Check Coverage",
-      gradient: "bg-gradient-electric"
-    }
+      gradient: "bg-gradient-electric",
+    },
   ];
 
   return (
     <section className="py-20 bg-muted/30" id="contact">
       <div className="container mx-auto px-4">
-        {/* Section Header */}
         <div className="text-center mb-16">
           <Badge className="mb-4 bg-gradient-primary text-white">Get Your Free Estimate</Badge>
           <h2 className="text-4xl md:text-5xl font-bold mb-6 text-foreground">
@@ -150,33 +221,27 @@ const ContactForm = () => {
         </div>
 
         <div className="grid lg:grid-cols-3 gap-12">
-          {/* Contact Methods */}
           <div className="space-y-6">
-            <h3 className="text-2xl font-bold mb-6 text-foreground">Get In Touch</h3>
-            
             {contactMethods.map((method, index) => (
-              <Card key={index} className="group hover:shadow-lg transition-all duration-300 border-0 overflow-hidden">
+              <Card key={index} className="hover:shadow-xl transition-all duration-300 border-0 glow-primary group">
                 <CardContent className="p-6">
-                  <div className="flex items-start gap-4">
-                    <div className={`p-3 rounded-lg ${method.gradient} text-white flex-shrink-0`}>
+                  <div className="flex items-start space-x-4">
+                    <div className={`${method.gradient} text-white p-3 rounded-lg group-hover:scale-110 transition-transform duration-300`}>
                       {method.icon}
                     </div>
                     <div className="flex-1">
-                      <h4 className="font-semibold text-foreground mb-1">{method.title}</h4>
-                      <p className="font-bold text-lg text-primary mb-1">{method.value}</p>
+                      <h3 className="font-semibold text-lg text-foreground mb-1">{method.title}</h3>
+                      <p className="text-primary font-medium mb-1">{method.value}</p>
                       <p className="text-sm text-muted-foreground mb-3">{method.description}</p>
-                      <Button 
-                        variant="outline" 
-                        size="sm" 
+                      <Button
+                        variant="outline"
+                        size="sm"
                         className="text-xs"
                         onClick={() => {
                           if (method.title === "Call or Text") {
                             window.location.href = phone.href;
                           } else if (method.title === "Email") {
-                            window.location.href = "mailto:integrityevsolutions@gmail.com";
-                          } else if (method.title === "Service Area") {
-                            // Show coverage info
-                            alert("We proudly serve all of Northern Georgia including Atlanta, Alpharetta, Roswell, Marietta, Decatur, Duluth, Lawrenceville, Johns Creek, Sandy Springs, Brookhaven, and surrounding areas. Licensed for statewide service!");
+                            window.location.href = `mailto:${CONTACT_EMAIL}`;
                           }
                         }}
                       >
@@ -188,25 +253,20 @@ const ContactForm = () => {
               </Card>
             ))}
 
-            {/* Emergency Notice */}
-            <div className="bg-accent/10 border border-accent/30 rounded-lg p-6">
-              <div className="flex items-center gap-3 mb-3">
-                <Clock className="w-6 h-6 text-accent" />
-                <h4 className="font-bold text-accent">24/7 Emergency Service</h4>
+            <div className="bg-gradient-primary text-white p-6 rounded-xl glow-primary">
+              <div className="flex items-center space-x-3 mb-4">
+                <Clock className="w-6 h-6" />
+                <h3 className="font-bold text-lg">Emergency Service</h3>
               </div>
-              <p className="text-sm text-foreground mb-3">
-                Electrical emergencies can't wait. We're available around the clock for urgent electrical issues.
+              <p className="mb-4 text-white/90">
+                Need urgent electrical work? We offer emergency services for critical electrical issues.
               </p>
-              <Button 
-                className="w-full bg-gradient-accent glow-accent"
-                onClick={() => window.location.href = phone.href}
-              >
+              <Button className="w-full bg-gradient-accent glow-accent" onClick={() => (window.location.href = phone.href)}>
                 Call Emergency Line
               </Button>
             </div>
           </div>
 
-          {/* Contact Form */}
           <div className="lg:col-span-2">
             <Card className="border-0 glow-primary">
               <CardHeader>
@@ -215,43 +275,43 @@ const ContactForm = () => {
                   Request Your Free Estimate
                 </CardTitle>
                 <p className="text-muted-foreground">
-                  Fill out the form below and we'll contact you within 24 hours with a detailed estimate.
+                  Fill out the form below, then choose email or call/text. Your details stay on this page until you send them from your email app.
                 </p>
               </CardHeader>
-              
+
               <CardContent>
-                <form
-                  onSubmit={handleSubmit}
-                  action={FORMSUBMIT_FORM_ENDPOINT}
-                  method="POST"
-                  className="space-y-6"
-                >
-                  {/* FormSubmit configuration */}
-                  <input type="hidden" name="_captcha" value="false" />
-                  <input type="hidden" name="_template" value="table" />
-                  <input
-                    type="hidden"
-                    name="_subject"
-                    value="New EV Charger Lead - Integrity EV Solutions"
-                  />
-                  <input
-                    type="hidden"
-                    name="_next"
-                    value={`${typeof window !== "undefined" ? window.location.origin : ""}/thank-you`}
-                  />
-                  <input type="hidden" name="lead_source" value={utmParams.utm_source} />
-                  <input type="hidden" name="lead_medium" value={utmParams.utm_medium} />
-                  <input type="hidden" name="lead_campaign" value={utmParams.utm_campaign} />
-                  {/* Personal Info */}
+                <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+                  <div className="rounded-lg border border-primary/20 bg-primary/5 p-4 text-sm text-muted-foreground">
+                    <p>
+                      <strong className="text-foreground">No backend required:</strong> this form opens your email app with the estimate details already filled in. If email does not open, call or text {phone.display}.
+                    </p>
+                  </div>
+
                   <div className="grid md:grid-cols-2 gap-4">
                     <div>
                       <Label htmlFor="firstName">First Name *</Label>
-                      <Input id="firstName" name="firstName" required className="mt-1" />
+                      <Input
+                        id="firstName"
+                        name="firstName"
+                        value={formData.firstName}
+                        onChange={(e) => updateField("firstName", e.target.value)}
+                        required
+                        className="mt-1"
+                        autoComplete="given-name"
+                      />
                       {errors.firstName && <p className="text-sm text-destructive mt-1">{errors.firstName}</p>}
                     </div>
                     <div>
                       <Label htmlFor="lastName">Last Name *</Label>
-                      <Input id="lastName" name="lastName" required className="mt-1" />
+                      <Input
+                        id="lastName"
+                        name="lastName"
+                        value={formData.lastName}
+                        onChange={(e) => updateField("lastName", e.target.value)}
+                        required
+                        className="mt-1"
+                        autoComplete="family-name"
+                      />
                       {errors.lastName && <p className="text-sm text-destructive mt-1">{errors.lastName}</p>}
                     </div>
                   </div>
@@ -259,66 +319,94 @@ const ContactForm = () => {
                   <div className="grid md:grid-cols-2 gap-4">
                     <div>
                       <Label htmlFor="email">Email Address *</Label>
-                      <Input id="email" name="email" type="email" required className="mt-1" />
+                      <Input
+                        id="email"
+                        name="email"
+                        type="email"
+                        value={formData.email}
+                        onChange={(e) => updateField("email", e.target.value)}
+                        required
+                        className="mt-1"
+                        autoComplete="email"
+                      />
                       {errors.email && <p className="text-sm text-destructive mt-1">{errors.email}</p>}
                     </div>
                     <div>
                       <Label htmlFor="phone">Phone Number *</Label>
-                      <Input id="phone" name="phone" type="tel" required className="mt-1" />
+                      <Input
+                        id="phone"
+                        name="phone"
+                        type="tel"
+                        value={formData.phone}
+                        onChange={(e) => updateField("phone", e.target.value)}
+                        required
+                        className="mt-1"
+                        autoComplete="tel"
+                      />
                       {errors.phone && <p className="text-sm text-destructive mt-1">{errors.phone}</p>}
                     </div>
                   </div>
 
-                  {/* Service Info */}
                   <div>
                     <Label htmlFor="service">Service Needed *</Label>
-                    <Select required onValueChange={setService}>
-                      <SelectTrigger className="mt-1">
-                        <SelectValue placeholder="Select the service you need" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="residential-ev">Residential EV Charger Installation</SelectItem>
-                        <SelectItem value="commercial-ev">Commercial EV Charging</SelectItem>
-                        <SelectItem value="tesla-powerwall">Tesla Powerwall Installation</SelectItem>
-                        <SelectItem value="panel-upgrade">Electrical Panel Upgrade</SelectItem>
-                        <SelectItem value="general-electrical">General Electrical Work</SelectItem>
-                        <SelectItem value="emergency">Emergency Service</SelectItem>
-                        <SelectItem value="consultation">Consultation Only</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <input type="hidden" name="service" value={service} />
+                    <select
+                      id="service"
+                      name="service"
+                      value={formData.service}
+                      onChange={(e) => updateField("service", e.target.value)}
+                      required
+                      className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    >
+                      <option value="">Select the service you need</option>
+                      {serviceOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
                     {errors.service && <p className="text-sm text-destructive mt-1">{errors.service}</p>}
                   </div>
 
                   <div className="grid md:grid-cols-2 gap-4">
                     <div>
                       <Label htmlFor="city">City *</Label>
-                      <Input id="city" name="city" required className="mt-1" />
+                      <Input
+                        id="city"
+                        name="city"
+                        value={formData.city}
+                        onChange={(e) => updateField("city", e.target.value)}
+                        required
+                        className="mt-1"
+                        autoComplete="address-level2"
+                      />
                       {errors.city && <p className="text-sm text-destructive mt-1">{errors.city}</p>}
                     </div>
                     <div>
                       <Label htmlFor="timeline">Preferred Timeline</Label>
-                      <Select onValueChange={setTimeline}>
-                        <SelectTrigger className="mt-1">
-                          <SelectValue placeholder="When do you need this completed?" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="asap">As soon as possible</SelectItem>
-                          <SelectItem value="1-2-weeks">Within 1-2 weeks</SelectItem>
-                          <SelectItem value="1-month">Within 1 month</SelectItem>
-                          <SelectItem value="flexible">I'm flexible</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <input type="hidden" name="timeline" value={timeline} />
+                      <select
+                        id="timeline"
+                        name="timeline"
+                        value={formData.timeline}
+                        onChange={(e) => updateField("timeline", e.target.value)}
+                        className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      >
+                        <option value="">When do you need this completed?</option>
+                        {timelineOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
                     </div>
                   </div>
 
-                  {/* Project Details */}
                   <div>
                     <Label htmlFor="details">Project Details</Label>
                     <Textarea
                       id="details"
                       name="details"
+                      value={formData.details}
+                      onChange={(e) => updateField("details", e.target.value)}
                       placeholder="Tell us about your project, any specific requirements, questions, or concerns..."
                       className="mt-1 min-h-[120px]"
                       maxLength={2000}
@@ -326,26 +414,52 @@ const ContactForm = () => {
                     {errors.details && <p className="text-sm text-destructive mt-1">{errors.details}</p>}
                   </div>
 
-                  {/* Submit Button */}
-                  <Button 
-                    type="submit" 
-                    className="w-full bg-gradient-accent glow-accent hover:scale-[1.02] transition-all duration-300 text-lg py-6 h-auto font-semibold"
-                    disabled={isSubmitting}
-                  >
-                    {isSubmitting ? (
-                      <>
-                        <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-accent-foreground mr-2"></div>
-                        Sending Request...
-                      </>
-                    ) : (
-                      <>
-                        <Send className="w-5 h-5 mr-2" />
-                        Get My Free Estimate
-                      </>
-                    )}
-                  </Button>
+                  <div className="grid sm:grid-cols-2 gap-3">
+                    <Button
+                      type="submit"
+                      className="w-full bg-gradient-accent glow-accent hover:scale-[1.02] transition-all duration-300 text-lg py-6 h-auto font-semibold"
+                    >
+                      <Send className="w-5 h-5 mr-2" />
+                      Open Email to Send
+                    </Button>
+                    <Button
+                      asChild
+                      variant="outline"
+                      className="w-full text-lg py-6 h-auto font-semibold"
+                      onClick={(e) => {
+                        if (!validateForm()) {
+                          e.preventDefault();
+                        }
+                      }}
+                    >
+                      <a href={mailtoLink}>
+                        <ExternalLink className="w-5 h-5 mr-2" />
+                        Email Manually
+                      </a>
+                    </Button>
+                  </div>
 
-                  {/* Trust Indicators */}
+                  {hasValidated && (
+                    <div className="rounded-lg border border-primary/20 bg-primary/5 p-4 text-sm text-muted-foreground">
+                      <p className="font-semibold text-foreground">Your estimate request is ready to send.</p>
+                      <p>
+                        If your email app did not open, call or text <a className="font-medium text-primary underline" href={phone.href}>{phone.display}</a> or email <a className="font-medium text-primary underline" href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+                      </p>
+                      <div className="mt-3 space-y-2">
+                        <Button type="button" variant="outline" size="sm" onClick={copyEstimateDetails}>
+                          Copy Request Details
+                        </Button>
+                        {copyMessage && <p>{copyMessage}</p>}
+                        <Textarea
+                          readOnly
+                          value={buildEstimateSummary(formData, utmParams)}
+                          className="min-h-[180px] bg-background text-xs"
+                          aria-label="Estimate request details"
+                        />
+                      </div>
+                    </div>
+                  )}
+
                   <div className="flex flex-col sm:flex-row items-center justify-center gap-4 text-sm text-muted-foreground pt-4 border-t border-border">
                     <div className="flex items-center gap-2">
                       <CheckCircle className="w-4 h-4 text-primary" />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -29,9 +29,9 @@ function restoreSpaRedirect() {
     }
 
     // Backward compat: legacy format (only if no existing query params)
-    const legacy = (sessionStorage as any).redirect;
+    const legacy = sessionStorage.getItem("redirect");
     if (legacy) {
-      delete (sessionStorage as any).redirect;
+      sessionStorage.removeItem("redirect");
       if (legacy !== "/" && !window.location.search) {
         window.history.replaceState(null, "", "/" + legacy);
       }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import { htmlPrerender } from "vite-plugin-html-prerender";
 // All routes that need to be pre-rendered for SEO
 const routes = [
   "/",
+  "/index",
   "/privacy-policy",
   "/terms-of-service",
   "/sitemap",


### PR DESCRIPTION
### Motivation
- Replace the external FormSubmit POST with an email-first workflow so users can send estimate requests from their email app without a backend.
- Improve client-side validation, provide clearer field messages, and make service/timeline options explicit to reduce invalid leads.
- Preserve UTM attribution and give users a copyable estimate summary for manual submission when email apps fail.
- Fix legacy `sessionStorage` redirect handling and ensure `/index` is pre-rendered for SEO.

### Description
- Reworked `ContactForm.tsx` to use local `formData` state and `zod` validation with friendlier error messages and a more permissive phone regex, plus added `ContactFormErrors`, `initialFormData`, `serviceOptions`, and `timelineOptions` helpers.
- Removed the FormSubmit hidden POST flow and replaced it with a `mailto:`-based flow using `buildEstimateSummary` and `buildMailtoLink`, plus a clipboard `copyEstimateDetails` helper and UI for previewing/copying the generated request.
- Updated contact cards and emergency section visuals and behavior, standardized contact email via `CONTACT_EMAIL`, and adjusted icons/import ordering and button behaviors to use constants like `phone.href` and `mailto:` links.
- Fixed `main.tsx` sessionStorage legacy handling by using `sessionStorage.getItem`/`removeItem`, and added `"/index"` to the pre-render `routes` list in `vite.config.ts`.

### Testing
- Ran TypeScript type-check with `tsc --noEmit`, which completed successfully.
- Performed a production build with `vite build`, which completed successfully and produced the expected output.
- Started a local dev server (`npm run dev`) and manually exercised the contact form flow and mailto behavior in the browser with UTM query params present, observing expected UI and mailto invocation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cc67233788331a4188590d56c06f5)